### PR TITLE
Improve upload safety and data validation

### DIFF
--- a/arima_project/src/arima_analyzer.py
+++ b/arima_project/src/arima_analyzer.py
@@ -21,7 +21,15 @@ def load_data(filepath, date_column, value_column):
     try:
         data = pd.read_csv(filepath, parse_dates=[date_column], index_col=date_column)
         ts = data[value_column]
-        ts = ts.asfreq(pd.infer_freq(ts.index)) # Infer frequency
+        ts = pd.to_numeric(ts, errors='coerce')
+        if ts.isna().all():
+            print(f"Error: Column '{value_column}' contains no numeric data.")
+            return None
+        freq = pd.infer_freq(ts.index)
+        if freq:
+            ts = ts.asfreq(freq) # Infer frequency
+        else:
+            print("Warning: Could not infer frequency from index. Proceeding without setting frequency.")
         return ts
     except FileNotFoundError:
         print(f"Error: File not found at {filepath}")


### PR DESCRIPTION
### Motivation
- Prevent unsafe handling of uploaded CSVs in the Streamlit app by avoiding fixed temp filenames and adding upload size limits to reduce resource/abuse risk.
- Harden CSV loading so non-numeric value columns and cases where the index frequency cannot be inferred are handled gracefully to avoid runtime errors.

### Description
- In `arima_project/app/app.py` add `import tempfile`, enforce a 10 MB upload size limit via `uploaded_file.size`, and write the upload to a `tempfile.NamedTemporaryFile` then always remove it in a `finally` block.
- In `arima_project/src/arima_analyzer.py` update `load_data` to coerce the `value_column` to numeric using `pd.to_numeric(..., errors='coerce')` and return `None` with a clear message if the column contains no numeric data.
- In `load_data` only call `pd.infer_freq` and set frequency with `ts.asfreq(freq)` when `pd.infer_freq(ts.index)` returns a valid frequency, otherwise emit a warning and proceed without changing the index frequency.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989ec7eef2c83248510f38ef76922e0)